### PR TITLE
SignInWithAppleService refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ At runtime, create an instance of `SignInWithAppleConfiguration`, supplying thes
 - `clientId`: Use the client ID value from service setup.
 - `redirectUri`: Use the redirect URI value from service setup.
 - `scope`: Specify a space-delimited string of OpenID scopes, like "name email".
+- `verifyState`: A explicit workaround for instances that has no state parameter being returned
 
 > According to our understanding of OpenID Connect, the "openid" scope should be included. But at this time of writing, that causes the authentication page to fail to initialize. Beta idiosyncrasies like these are documented in [How Sign in with Apple differs from OpenID Connect](https://bitbucket.org/openid/connect/src/default/How-Sign-in-with-Apple-differs-from-OpenID-Connect.md).
 
@@ -123,7 +124,8 @@ override fun onCreate(savedInstanceState: Bundle?) {
     val configuration = SignInWithAppleConfiguration(
         clientId = "com.your.client.id.here",
         redirectUri = "https://your-redirect-uri.com/callback",
-        scope = "email"
+        scope = "email",
+        true
     )
 
     val signInWithAppleButton = findViewById(R.id.sign_in_with_apple_button)

--- a/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleActivity.kt
+++ b/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleActivity.kt
@@ -20,10 +20,12 @@ class SampleActivity : AppCompatActivity() {
         val signInWithAppleButtonWhiteOutline: SignInWithAppleButton = findViewById(R.id.sign_in_with_apple_button_white_outline)
 
         // Replace clientId and redirectUri with your own values.
+        // TODO: Use keystore property file
         val configuration = SignInWithAppleConfiguration(
             clientId = "com.your.client.id.here",
             redirectUri = "https://your-redirect-uri.com/callback",
-            scope = "email name"
+            scope = "email name",
+            verifyState = true
         )
 
         val callback: (SignInWithAppleResult) -> Unit = { result ->

--- a/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleActivity.kt
+++ b/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleActivity.kt
@@ -29,7 +29,7 @@ class SampleActivity : AppCompatActivity() {
         val callback: (SignInWithAppleResult) -> Unit = { result ->
             when (result) {
                 is SignInWithAppleResult.Success -> {
-                    Toast.makeText(this, result.authorizationCode, LENGTH_SHORT).show()
+                    Toast.makeText(this, "CODE: " + result.code, LENGTH_SHORT).show()
                 }
                 is SignInWithAppleResult.Failure -> {
                     Log.d("SAMPLE_APP", "Received error from Apple Sign In ${result.error.message}")

--- a/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleJavaActivity.java
+++ b/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleJavaActivity.java
@@ -13,6 +13,15 @@ import com.willowtreeapps.signinwithapplebutton.SignInWithAppleCallback;
 import com.willowtreeapps.signinwithapplebutton.SignInWithAppleService;
 import com.willowtreeapps.signinwithapplebutton.view.SignInWithAppleButton;
 
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+import kotlin.collections.MapsKt;
+
 import static android.widget.Toast.LENGTH_SHORT;
 
 public class SampleJavaActivity extends AppCompatActivity {
@@ -35,8 +44,10 @@ public class SampleJavaActivity extends AppCompatActivity {
 
         SignInWithAppleCallback callback = new SignInWithAppleCallback() {
             @Override
-            public void onSignInWithAppleSuccess(@NonNull String authorizationCode) {
-                Toast.makeText(SampleJavaActivity.this, authorizationCode, LENGTH_SHORT).show();
+            public void onSignInWithAppleSuccess(@NotNull String authorizationCode, @NotNull Map<String, String> scopes) {
+                Toast.makeText(SampleJavaActivity.this,
+                        "CODE: " + authorizationCode,
+                        LENGTH_SHORT).show();
             }
 
             @Override

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleCallback.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleCallback.kt
@@ -2,7 +2,7 @@ package com.willowtreeapps.signinwithapplebutton
 
 interface SignInWithAppleCallback {
 
-    fun onSignInWithAppleSuccess(authorizationCode: String)
+    fun onSignInWithAppleSuccess(authorizationCode: String, scopes: MutableMap<String, String>)
 
     fun onSignInWithAppleFailure(error: Throwable)
 
@@ -12,7 +12,7 @@ interface SignInWithAppleCallback {
 internal fun SignInWithAppleCallback.toFunction(): (SignInWithAppleResult) -> Unit =
     { result ->
         when (result) {
-            is SignInWithAppleResult.Success -> onSignInWithAppleSuccess(result.authorizationCode)
+            is SignInWithAppleResult.Success -> onSignInWithAppleSuccess(result.code, result.scopes)
             is SignInWithAppleResult.Failure -> onSignInWithAppleFailure(result.error)
             is SignInWithAppleResult.Cancel -> onSignInWithAppleCancel()
         }

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleConfiguration.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleConfiguration.kt
@@ -3,13 +3,20 @@ package com.willowtreeapps.signinwithapplebutton
 data class SignInWithAppleConfiguration(
     val clientId: String,
     val redirectUri: String,
-    val scope: String
+    val scope: String,
+    val verifyState: Boolean
 ) {
 
     class Builder {
+        // Client ID
         private lateinit var clientId: String
+        // Redirect URL string
         private lateinit var redirectUri: String
+        // Scope (mostly "name email")
         private lateinit var scope: String
+        // Workaround: Current Apple REST API doesn't
+        // return the state although we passed the state hash generated from our end.
+        private var verifyState: Boolean = true
 
         fun clientId(clientId: String) = apply {
             this.clientId = clientId
@@ -23,6 +30,10 @@ data class SignInWithAppleConfiguration(
             this.scope = scope
         }
 
-        fun build() = SignInWithAppleConfiguration(clientId, redirectUri, scope)
+        fun verifyState(verifyState: Boolean) = apply {
+            this.verifyState = verifyState
+        }
+
+        fun build() = SignInWithAppleConfiguration(clientId, redirectUri, scope, verifyState)
     }
 }

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleResult.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleResult.kt
@@ -1,8 +1,11 @@
 package com.willowtreeapps.signinwithapplebutton
 
 sealed class SignInWithAppleResult {
-    data class Success(val authorizationCode: String) : SignInWithAppleResult()
 
+    // Success with authorization code & scopes
+    data class Success(val code: String, val scopes: MutableMap<String, String>) : SignInWithAppleResult()
+
+    // Failure with throwable exception
     data class Failure(val error: Throwable) : SignInWithAppleResult()
 
     object Cancel : SignInWithAppleResult()

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleService.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleService.kt
@@ -18,7 +18,7 @@ class SignInWithAppleService(
     init {
         val fragmentIfShown =
             fragmentManager.findFragmentByTag(fragmentTag) as? SignInWebViewDialogFragment
-        fragmentIfShown?.configure(callback)
+        fragmentIfShown?.configureCallback(callback)
     }
 
     internal data class AuthenticationAttempt(
@@ -67,7 +67,7 @@ class SignInWithAppleService(
                     .parse("https://${Strings.APPLEID_URL}/auth/authorize")
                     .buildUpon().apply {
                         appendQueryParameter("response_type", "code")
-                        appendQueryParameter("v", "1.1.6")
+                        appendQueryParameter("v", "1.1.6") // TODO: Change version
                         appendQueryParameter("client_id", configuration.clientId)
                         appendQueryParameter("redirect_uri", configuration.redirectUri)
                         appendQueryParameter("scope", configuration.scope)
@@ -84,7 +84,8 @@ class SignInWithAppleService(
 
     fun show() {
         val fragment = SignInWebViewDialogFragment.newInstance(AuthenticationAttempt.create(configuration))
-        fragment.configure(callback)
+        fragment.configureCallback(callback)
+        fragment.configure(configuration)
         fragment.show(fragmentManager, fragmentTag)
     }
 }

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWebViewClient.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWebViewClient.kt
@@ -16,21 +16,14 @@ import com.willowtreeapps.signinwithapplebutton.SignInWithAppleService
 import com.willowtreeapps.signinwithapplebutton.constants.Strings
 import com.willowtreeapps.signinwithapplebutton.view.SignInWithAppleButton.Companion.SIGN_IN_WITH_APPLE_LOG_TAG
 
-/**
- * Will do some of the work here:
- * - Use shouldOverrideUrlLoading for checking redirect URL & current URL by using .startsWith()
- */
 internal class SignInWebViewClient(
     private val fragment: SignInWebViewDialogFragment,
-    private val config: SignInWithAppleConfiguration,
+    private val configuration: SignInWithAppleConfiguration,
     private val attempt: SignInWithAppleService.AuthenticationAttempt,
     private val callback: (SignInWithAppleResult) -> Unit
 ) : WebViewClient() {
 
     private val TAG: String = ::SignInWebViewClient.javaClass.simpleName
-    private var success: Boolean = false
-    private var failed: Boolean = false
-    private var gotError: Boolean = false
 
     // for API levels < 24
     override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
@@ -46,7 +39,6 @@ internal class SignInWebViewClient(
     @RequiresApi(Build.VERSION_CODES.KITKAT)
     override fun onPageStarted(view: WebView?, url: String, favicon: Bitmap?) {
         fragment.updateSubtitle(url)
-        setCallback(Uri.parse(url))
         super.onPageStarted(view, url, favicon)
     }
 
@@ -59,17 +51,26 @@ internal class SignInWebViewClient(
 
     override fun onReceivedError(view: WebView?, errorCode: Int, description: String?, url: String) {
         Log.d(TAG, "onReceivedError: $url")
-        gotError = true // set status to avoid override by onPageFinished()
         callback(SignInWithAppleResult.Failure(NetworkErrorException("onReceivedError")))
     }
 
     private fun isUrlOverridden(view: WebView?, url: Uri?): Boolean {
+        /*
+         * This fixes the issue:
+         * https://github.com/willowtreeapps/sign-in-with-apple-button-android/issues/68
+         */
+        val redirectUrlResult: String = attempt.redirectUri.replace("/handler", "/result")
+
         return when {
             url == null -> {
                 false
             }
             url.toString().contains(Strings.APPLEID_URL) -> {
                 view?.loadUrl(url.toString())
+                true
+            }
+            url.toString().contains(redirectUrlResult) -> {
+                setCallback(url)
                 true
             }
             else -> {
@@ -79,52 +80,35 @@ internal class SignInWebViewClient(
     }
 
     private fun setCallback(url: Uri) {
-        // workaround
-        val redirectUrlResult: String = attempt.redirectUri.replace("/handler", "/result")
-        if (url.toString().contains(redirectUrlResult)) {
-            // TODO: getQueryParameter by scope
-            Log.d(SIGN_IN_WITH_APPLE_LOG_TAG, "Web view was forwarded to redirect URI")
-            val codeParameter = url.getQueryParameter("uuid") // based on thorough test of latest Apple's REST API
-            // val stateParameter = url.getQueryParameter("state") // not exists on the latest Apple's REST API
-            val authParameter = url.getQueryParameter("auth")
-            // parse scopes
-            val scopeParameter: String = config.scope
-            val scopes: Array<String> = scopeParameter.split(" ").toTypedArray()
-            val scopesMutable = mutableMapOf<String, String>()
-            for (scope in scopes) {
-                scopesMutable[scope] = url.getQueryParameter(scope).toString()
+        Log.d(SIGN_IN_WITH_APPLE_LOG_TAG, "Web view was forwarded to redirect URI")
+        val codeParameter = url.getQueryParameter("uuid") // based on thorough test of latest Apple's REST API
+        val stateParameter = url.getQueryParameter("state") // WARN: not exists on the latest Apple's REST API
+        val authParameter = url.getQueryParameter("auth")
+        // parse scopes from url
+        val scopes: Array<String> = configuration.scope.split(" ").toTypedArray()
+        val scopesMutable = mutableMapOf<String, String>()
+        for (scope in scopes) {
+            scopesMutable[scope] = url.getQueryParameter(scope).toString()
+        }
+        when {
+            codeParameter == null -> {
+                callback(SignInWithAppleResult.Failure(IllegalArgumentException("code not returned")))
             }
-            when {
-                codeParameter == null -> {
-                    callback(SignInWithAppleResult.Failure(IllegalArgumentException("code not returned")))
-                }
-                /*
-                stateParameter != attempt.state || authParameter != attempt.state -> {
-                    callback(SignInWithAppleResult.Failure(IllegalArgumentException("state does not match")))
-                }
-                 */
-                // workaround
-                authParameter == "success" -> {
-                    attempt.state
-                    callback(SignInWithAppleResult.Success(codeParameter, scopesMutable))
-                }
-                else -> {
-                    callback(SignInWithAppleResult.Success(codeParameter, scopesMutable))
-                }
+            // Workaround: make sure that the verifyState is true and stateParameter does not exists
+            configuration.verifyState && stateParameter != null && stateParameter != attempt.state -> {
+                callback(SignInWithAppleResult.Failure(IllegalArgumentException("state does not match")))
             }
-        } else {
-            Toast.makeText(
-                fragment.context,
-                "onPageStarted: $url \n" + "redirectUrl: ${attempt.redirectUri}",
-                Toast.LENGTH_LONG
-            ).show()
+            authParameter == "success" -> {
+                callback(SignInWithAppleResult.Success(codeParameter, scopesMutable))
+            }
+            else -> {
+                // TODO: Needs citing for this error message
+                callback(SignInWithAppleResult.Failure(IllegalArgumentException("access denied")))
+            }
         }
     }
 
     private fun hideProgress() {
-        // val progress: ProgressBar findViewById(R.id.a)
-        // progress.setVisibility(View.GONE)
-        Log.e(TAG, "NO PROGRESS BAR YET!")
         fragment.hideProgress()
     }
 

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWebViewDialogFragment.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWebViewDialogFragment.kt
@@ -2,7 +2,6 @@ package com.willowtreeapps.signinwithapplebutton.view
 
 import android.annotation.SuppressLint
 import android.content.DialogInterface
-import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -12,12 +11,14 @@ import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
-import android.webkit.WebSettings
 import android.webkit.WebView
-import android.widget.Toast
+import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.DialogFragment
-import com.willowtreeapps.signinwithapplebutton.*
+import com.willowtreeapps.signinwithapplebutton.R
+import com.willowtreeapps.signinwithapplebutton.SignInWithAppleConfiguration
+import com.willowtreeapps.signinwithapplebutton.SignInWithAppleResult
+import com.willowtreeapps.signinwithapplebutton.SignInWithAppleService
 import com.willowtreeapps.signinwithapplebutton.constants.Strings
 import com.willowtreeapps.signinwithapplebutton.view.SignInWithAppleButton.Companion.SIGN_IN_WITH_APPLE_LOG_TAG
 import kotlinx.android.synthetic.main.sign_in_with_apple_button_dialog.*
@@ -93,13 +94,13 @@ internal class SignInWebViewDialogFragment : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
         // finish setup toolbar
         (activity as AppCompatActivity?)!!.setSupportActionBar(toolbar)
-        if ((activity as AppCompatActivity?)!!.supportActionBar != null) {
-            (activity as AppCompatActivity?)!!.supportActionBar!!.setDisplayHomeAsUpEnabled(true)
-            (activity as AppCompatActivity?)!!.supportActionBar!!.title = Strings.APPlEID_TITLE
-            (activity as AppCompatActivity?)!!.supportActionBar!!.subtitle = "Loading..."
+        val actionBar: ActionBar? = (activity as AppCompatActivity?)?.supportActionBar
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true)
+            actionBar.title = Strings.APPlEID_TITLE
+            actionBar.subtitle = "Loading..."
         }
     }
 
@@ -142,8 +143,9 @@ internal class SignInWebViewDialogFragment : DialogFragment() {
     }
 
     fun updateSubtitle(string: String) {
-        if ((activity as AppCompatActivity?)!!.supportActionBar != null) {
-            (activity as AppCompatActivity?)!!.supportActionBar!!.subtitle = string
+        val actionBar: ActionBar? = (activity as AppCompatActivity?)?.supportActionBar
+        if (actionBar != null) {
+            actionBar.subtitle = string
         }
     }
 

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWebViewDialogFragment.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWebViewDialogFragment.kt
@@ -17,10 +17,7 @@ import android.webkit.WebView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.DialogFragment
-import com.willowtreeapps.signinwithapplebutton.BuildConfig
-import com.willowtreeapps.signinwithapplebutton.R
-import com.willowtreeapps.signinwithapplebutton.SignInWithAppleResult
-import com.willowtreeapps.signinwithapplebutton.SignInWithAppleService
+import com.willowtreeapps.signinwithapplebutton.*
 import com.willowtreeapps.signinwithapplebutton.constants.Strings
 import com.willowtreeapps.signinwithapplebutton.view.SignInWithAppleButton.Companion.SIGN_IN_WITH_APPLE_LOG_TAG
 import kotlinx.android.synthetic.main.sign_in_with_apple_button_dialog.*
@@ -44,12 +41,17 @@ internal class SignInWebViewDialogFragment : DialogFragment() {
 
     private lateinit var authenticationAttempt: SignInWithAppleService.AuthenticationAttempt
     private var callback: ((SignInWithAppleResult) -> Unit)? = null
+    private var config: SignInWithAppleConfiguration? = null
 
     private val webViewIfCreated: WebView?
         get() = view as? WebView
 
-    fun configure(callback: (SignInWithAppleResult) -> Unit) {
+    fun configureCallback(callback: (SignInWithAppleResult) -> Unit) {
         this.callback = callback
+    }
+
+    fun configure(config: SignInWithAppleConfiguration) {
+        this.config = config
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -72,28 +74,17 @@ internal class SignInWebViewDialogFragment : DialogFragment() {
         // val webView: WebView? = dialog?.window?.findViewById(R.id.web_view)
         webView.settings?.javaScriptEnabled  = true
         webView.settings?.javaScriptCanOpenWindowsAutomatically = true
-        webView.webViewClient = SignInWebViewClient(this, authenticationAttempt, ::onCallback)
+        webView.webViewClient =
+            config?.let { SignInWebViewClient(this, it, authenticationAttempt, ::onCallback) }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            // chromium, enable hardware acceleration
-            webView.setLayerType(View.LAYER_TYPE_HARDWARE, null)
-        } else {
-            // older android version, disable hardware acceleration
-            webView.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
-        }
+        // chromium, enable hardware acceleration
+        webView.setLayerType(View.LAYER_TYPE_HARDWARE, null)
 
         if (savedInstanceState != null) {
             savedInstanceState.getBundle(WEB_VIEW_KEY)?.run {
                 webView.restoreState(this)
             }
         } else {
-            if (BuildConfig.DEBUG) {
-                Toast.makeText(
-                    context,
-                    "Loading: " + authenticationAttempt.authenticationUri,
-                    Toast.LENGTH_LONG
-                ).show()
-            }
             webView.loadUrl(authenticationAttempt.authenticationUri)
         }
 


### PR DESCRIPTION
## Changes

- Adjusted callback in accordance with the latest documentation of Apple's REST API, and with experience of using Apple Sign-in on an iOS app with Custom Authentication server (still using Apple's REST)
- Added `auth` parameter
   - Added `success` workaround
- Set `state` as an optional parameter which is also the culprit of the callback issue
- Replace redirect URL `/handler` into `/result` when it comes to verifying the callback
- Code cleanup

## Fixes the following:

- willowtreeapps/sign-in-with-apple-button-android#66
- willowtreeapps/sign-in-with-apple-button-android#68
- willowtreeapps/sign-in-with-apple-button-android#54
- willowtreeapps/sign-in-with-apple-button-android#50 (Getting scopes but not yet final)

## References:

- https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api